### PR TITLE
Fix bugs

### DIFF
--- a/awadb/__init__.py
+++ b/awadb/__init__.py
@@ -635,25 +635,6 @@ class Client:
             docs_detail.append(doc_detail)
         return docs_detail
 
-    def EmbedQuery(
-        self,
-        text: str,
-        **kwargs: Any,
-    ):
-        # print('enter EmbedQuery....')
-        # texts = []
-        # texts.append(text)
-        if self.llm is None:
-            from awadb import llm_embedding
-
-            self.llm = llm_embedding.LLMEmbedding()
-        # print(text)
-        return self.llm.Embedding(text)
-
-        # embeddings = self.llm.EmbeddingQuery(text)
-        # print(embeddings)
-        # return embeddings
-
     def __TextPreprocess(
         self,
         text: str,

--- a/setup.py
+++ b/setup.py
@@ -136,9 +136,9 @@ class CMakeBuild(build_ext):
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="awadb",
-    version="0.3.7",
+    version="0.3.8",
     author="Vincent",
-    author_email="awadb.jie@gmail.com",
+    author_email="awadb.vincent@gmail.com",
     description="AI Native database for embedding vectors",
     long_description="AI Native database for embedding vectors",
     license="Apache 2.0",


### PR DESCRIPTION
Fix the bugs below:
    1. The usage of pybind11 struct iterator may cause crash in MacOSX x86
       environment.
    2. The field of 'embedding_text' should not be indexed by numeric field
       indexing, too long text may cause buffer overflow.